### PR TITLE
Fix typo

### DIFF
--- a/libs/redux-libs/actions.js
+++ b/libs/redux-libs/actions.js
@@ -599,7 +599,7 @@ function startLongPolling(connection_id) {
       .then( json => {
         if(json === null) {
           // when response is ng, just restart long polling
-          dispatch(stargLongPolling(connection_id))
+          dispatch(startLongPolling(connection_id))
         } else {
           // dispatch reciveLongPolling function to change start
           dispatch(receiveLongPolling(connection_id, json))


### PR DESCRIPTION
I found a typo in `libs/redux-libs/actions.js`.
This commit may fix a crash caused by `UnhandledPromiseRejectionWarning` when ssg restarts long-polling.